### PR TITLE
Add unit tests for REST API endpoints and shopping cart functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ erDiagram
    ```bash
    npm run dev
    ```
+4. Run the tests:
+   ```bash
+   npm run test          # all tests
+   npm run test:api      # API tests only
+   npm run test:frontend # Frontend tests only
+   ```
 
 Or use the VS Code tasks:
 - `Cmd/Ctrl + Shift + P` -> `Run Task` -> `Build All`

--- a/api/src/routes/delivery.test.ts
+++ b/api/src/routes/delivery.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import deliveryRouter, { resetDeliveries } from './delivery';
+import { deliveries as seedDeliveries } from '../seedData';
+
+let app: express.Express;
+
+describe('Delivery API', () => {
+    beforeEach(() => {
+        app = express();
+        app.use(express.json());
+        app.use('/deliveries', deliveryRouter);
+        resetDeliveries();
+    });
+
+    it('should get all deliveries', async () => {
+        const response = await request(app).get('/deliveries');
+        expect(response.status).toBe(200);
+        expect(response.body.length).toBe(seedDeliveries.length);
+        response.body.forEach((delivery: any, index: number) => {
+            expect(delivery).toMatchObject(seedDeliveries[index]);
+        });
+    });
+
+    it('should get a delivery by ID', async () => {
+        const response = await request(app).get('/deliveries/1');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(seedDeliveries[0]);
+    });
+
+    it('should return 404 for non-existing delivery', async () => {
+        const response = await request(app).get('/deliveries/999');
+        expect(response.status).toBe(404);
+    });
+
+    it('should create a new delivery', async () => {
+        const newDelivery = {
+            deliveryId: 100,
+            supplierId: 1,
+            deliveryDate: new Date().toISOString(),
+            name: "Test Delivery",
+            description: "A test delivery",
+            status: "pending"
+        };
+        const response = await request(app).post('/deliveries').send(newDelivery);
+        expect(response.status).toBe(201);
+        expect(response.body).toEqual(newDelivery);
+    });
+
+    it('should update a delivery by ID', async () => {
+        const updatedDelivery = {
+            ...seedDeliveries[0],
+            name: 'Updated Delivery'
+        };
+        const response = await request(app).put('/deliveries/1').send(updatedDelivery);
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(updatedDelivery);
+    });
+
+    it('should return 404 when updating non-existing delivery', async () => {
+        const response = await request(app).put('/deliveries/999').send({ name: 'No Delivery' });
+        expect(response.status).toBe(404);
+    });
+
+    it('should update delivery status via PUT /:id/status', async () => {
+        const response = await request(app)
+            .put('/deliveries/1/status')
+            .send({ status: 'delivered' });
+        expect(response.status).toBe(200);
+        expect(response.body.status).toBe('delivered');
+    });
+
+    it('should return 404 when updating status of non-existing delivery', async () => {
+        const response = await request(app)
+            .put('/deliveries/999/status')
+            .send({ status: 'delivered' });
+        expect(response.status).toBe(404);
+    });
+
+    it('should delete a delivery by ID', async () => {
+        const response = await request(app).delete('/deliveries/1');
+        expect(response.status).toBe(204);
+    });
+
+    it('should return 404 when deleting non-existing delivery', async () => {
+        const response = await request(app).delete('/deliveries/999');
+        expect(response.status).toBe(404);
+    });
+});

--- a/api/src/routes/delivery.ts
+++ b/api/src/routes/delivery.ts
@@ -108,6 +108,10 @@ const router = express.Router();
 
 let deliveries: Delivery[] = [...seedDeliveries];
 
+export const resetDeliveries = () => {
+  deliveries = [...seedDeliveries];
+};
+
 // Create a new delivery
 router.post('/', (req, res) => {
   const newDelivery: Delivery = req.body;

--- a/api/src/routes/headquarters.test.ts
+++ b/api/src/routes/headquarters.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import headquartersRouter, { resetHeadquarters } from './headquarters';
+import { headquarters as seedHeadquarters } from '../seedData';
+
+let app: express.Express;
+
+describe('Headquarters API', () => {
+    beforeEach(() => {
+        app = express();
+        app.use(express.json());
+        app.use('/headquarters', headquartersRouter);
+        resetHeadquarters();
+    });
+
+    it('should get all headquarters', async () => {
+        const response = await request(app).get('/headquarters');
+        expect(response.status).toBe(200);
+        expect(response.body.length).toBe(seedHeadquarters.length);
+        response.body.forEach((hq: any, index: number) => {
+            expect(hq).toMatchObject(seedHeadquarters[index]);
+        });
+    });
+
+    it('should get a headquarters by ID', async () => {
+        const response = await request(app).get('/headquarters/1');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(seedHeadquarters[0]);
+    });
+
+    it('should return 404 for non-existing headquarters', async () => {
+        const response = await request(app).get('/headquarters/999');
+        expect(response.status).toBe(404);
+    });
+
+    it('should create a new headquarters', async () => {
+        const newHQ = {
+            headquartersId: 100,
+            name: "Test HQ",
+            description: "A test headquarters",
+            address: "123 Test St",
+            contactPerson: "Test Person",
+            email: "test@hq.com",
+            phone: "555-9999"
+        };
+        const response = await request(app).post('/headquarters').send(newHQ);
+        expect(response.status).toBe(201);
+        expect(response.body).toEqual(newHQ);
+    });
+
+    it('should update a headquarters by ID', async () => {
+        const updatedHQ = {
+            ...seedHeadquarters[0],
+            name: 'Updated HQ'
+        };
+        const response = await request(app).put('/headquarters/1').send(updatedHQ);
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(updatedHQ);
+    });
+
+    it('should return 404 when updating non-existing headquarters', async () => {
+        const response = await request(app).put('/headquarters/999').send({ name: 'No HQ' });
+        expect(response.status).toBe(404);
+    });
+
+    it('should delete a headquarters by ID', async () => {
+        const response = await request(app).delete('/headquarters/1');
+        expect(response.status).toBe(204);
+    });
+
+    it('should return 404 when deleting non-existing headquarters', async () => {
+        const response = await request(app).delete('/headquarters/999');
+        expect(response.status).toBe(404);
+    });
+});

--- a/api/src/routes/headquarters.ts
+++ b/api/src/routes/headquarters.ts
@@ -107,6 +107,10 @@ const router = express.Router();
 
 let headquartersList: Headquarters[] = [...seedHeadquarters];
 
+export const resetHeadquarters = () => {
+  headquartersList = [...seedHeadquarters];
+};
+
 // Create a new headquarters
 router.post('/', (req, res) => {
   const newHeadquarters: Headquarters = req.body;

--- a/api/src/routes/order.test.ts
+++ b/api/src/routes/order.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import orderRouter, { resetOrders } from './order';
+import { orders as seedOrders } from '../seedData';
+
+let app: express.Express;
+
+describe('Order API', () => {
+    beforeEach(() => {
+        app = express();
+        app.use(express.json());
+        app.use('/orders', orderRouter);
+        resetOrders();
+    });
+
+    it('should get all orders', async () => {
+        const response = await request(app).get('/orders');
+        expect(response.status).toBe(200);
+        expect(response.body.length).toBe(seedOrders.length);
+        response.body.forEach((order: any, index: number) => {
+            expect(order).toMatchObject(seedOrders[index]);
+        });
+    });
+
+    it('should get an order by ID', async () => {
+        const response = await request(app).get('/orders/1');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(seedOrders[0]);
+    });
+
+    it('should return 404 for non-existing order', async () => {
+        const response = await request(app).get('/orders/999');
+        expect(response.status).toBe(404);
+    });
+
+    it('should create a new order', async () => {
+        const newOrder = {
+            orderId: 100,
+            branchId: 1,
+            orderDate: new Date().toISOString(),
+            name: "Test Order",
+            description: "A test order",
+            status: "pending"
+        };
+        const response = await request(app).post('/orders').send(newOrder);
+        expect(response.status).toBe(201);
+        expect(response.body).toEqual(newOrder);
+    });
+
+    it('should update an order by ID', async () => {
+        const updatedOrder = {
+            ...seedOrders[0],
+            name: 'Updated Order'
+        };
+        const response = await request(app).put('/orders/1').send(updatedOrder);
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(updatedOrder);
+    });
+
+    it('should return 404 when updating non-existing order', async () => {
+        const response = await request(app).put('/orders/999').send({ name: 'No Order' });
+        expect(response.status).toBe(404);
+    });
+
+    it('should delete an order by ID', async () => {
+        const response = await request(app).delete('/orders/1');
+        expect(response.status).toBe(204);
+    });
+
+    it('should return 404 when deleting non-existing order', async () => {
+        const response = await request(app).delete('/orders/999');
+        expect(response.status).toBe(404);
+    });
+});

--- a/api/src/routes/order.ts
+++ b/api/src/routes/order.ts
@@ -107,6 +107,10 @@ const router = express.Router();
 
 let orders: Order[] = [...seedOrders];
 
+export const resetOrders = () => {
+  orders = [...seedOrders];
+};
+
 // Create a new order
 router.post('/', (req, res) => {
   const newOrder: Order = req.body;

--- a/api/src/routes/orderDetail.test.ts
+++ b/api/src/routes/orderDetail.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import orderDetailRouter, { resetOrderDetails } from './orderDetail';
+import { orderDetails as seedOrderDetails } from '../seedData';
+
+let app: express.Express;
+
+describe('OrderDetail API', () => {
+    beforeEach(() => {
+        app = express();
+        app.use(express.json());
+        app.use('/order-details', orderDetailRouter);
+        resetOrderDetails();
+    });
+
+    it('should get all order details', async () => {
+        const response = await request(app).get('/order-details');
+        expect(response.status).toBe(200);
+        expect(response.body.length).toBe(seedOrderDetails.length);
+        response.body.forEach((od: any, index: number) => {
+            expect(od).toMatchObject(seedOrderDetails[index]);
+        });
+    });
+
+    it('should get an order detail by ID', async () => {
+        const response = await request(app).get('/order-details/1');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(seedOrderDetails[0]);
+    });
+
+    it('should return 404 for non-existing order detail', async () => {
+        const response = await request(app).get('/order-details/999');
+        expect(response.status).toBe(404);
+    });
+
+    it('should create a new order detail', async () => {
+        const newOrderDetail = {
+            orderDetailId: 100,
+            orderId: 1,
+            productId: 1,
+            quantity: 10,
+            unitPrice: 129.99,
+            notes: "Test order detail"
+        };
+        const response = await request(app).post('/order-details').send(newOrderDetail);
+        expect(response.status).toBe(201);
+        expect(response.body).toEqual(newOrderDetail);
+    });
+
+    it('should update an order detail by ID', async () => {
+        const updatedOrderDetail = {
+            ...seedOrderDetails[0],
+            quantity: 10
+        };
+        const response = await request(app).put('/order-details/1').send(updatedOrderDetail);
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(updatedOrderDetail);
+    });
+
+    it('should return 404 when updating non-existing order detail', async () => {
+        const response = await request(app).put('/order-details/999').send({ quantity: 5 });
+        expect(response.status).toBe(404);
+    });
+
+    it('should delete an order detail by ID', async () => {
+        const response = await request(app).delete('/order-details/1');
+        expect(response.status).toBe(204);
+    });
+
+    it('should return 404 when deleting non-existing order detail', async () => {
+        const response = await request(app).delete('/order-details/999');
+        expect(response.status).toBe(404);
+    });
+});

--- a/api/src/routes/orderDetail.ts
+++ b/api/src/routes/orderDetail.ts
@@ -107,6 +107,10 @@ const router = express.Router();
 
 let orderDetails: OrderDetail[] = [...seedOrderDetails];
 
+export const resetOrderDetails = () => {
+  orderDetails = [...seedOrderDetails];
+};
+
 // Create a new order detail
 router.post('/', (req, res) => {
   const newOrderDetail: OrderDetail = req.body;

--- a/api/src/routes/orderDetailDelivery.test.ts
+++ b/api/src/routes/orderDetailDelivery.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import orderDetailDeliveryRouter, { resetOrderDetailDeliveries } from './orderDetailDelivery';
+import { orderDetailDeliveries as seedOrderDetailDeliveries } from '../seedData';
+
+let app: express.Express;
+
+describe('OrderDetailDelivery API', () => {
+    beforeEach(() => {
+        app = express();
+        app.use(express.json());
+        app.use('/order-detail-deliveries', orderDetailDeliveryRouter);
+        resetOrderDetailDeliveries();
+    });
+
+    it('should get all order detail deliveries', async () => {
+        const response = await request(app).get('/order-detail-deliveries');
+        expect(response.status).toBe(200);
+        expect(response.body.length).toBe(seedOrderDetailDeliveries.length);
+        response.body.forEach((odd: any, index: number) => {
+            expect(odd).toMatchObject(seedOrderDetailDeliveries[index]);
+        });
+    });
+
+    it('should get an order detail delivery by ID', async () => {
+        const response = await request(app).get('/order-detail-deliveries/1');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(seedOrderDetailDeliveries[0]);
+    });
+
+    it('should return 404 for non-existing order detail delivery', async () => {
+        const response = await request(app).get('/order-detail-deliveries/999');
+        expect(response.status).toBe(404);
+    });
+
+    it('should create a new order detail delivery', async () => {
+        const newODD = {
+            orderDetailDeliveryId: 100,
+            orderDetailId: 1,
+            deliveryId: 100,
+            quantity: 5,
+            notes: "Test delivery"
+        };
+        const response = await request(app).post('/order-detail-deliveries').send(newODD);
+        expect(response.status).toBe(201);
+        expect(response.body).toEqual(newODD);
+    });
+
+    it('should update an order detail delivery by ID', async () => {
+        const updatedODD = {
+            ...seedOrderDetailDeliveries[0],
+            quantity: 10
+        };
+        const response = await request(app).put('/order-detail-deliveries/1').send(updatedODD);
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(updatedODD);
+    });
+
+    it('should return 404 when updating non-existing order detail delivery', async () => {
+        const response = await request(app).put('/order-detail-deliveries/999').send({ quantity: 5 });
+        expect(response.status).toBe(404);
+    });
+
+    it('should delete an order detail delivery by ID', async () => {
+        const response = await request(app).delete('/order-detail-deliveries/1');
+        expect(response.status).toBe(204);
+    });
+
+    it('should return 404 when deleting non-existing order detail delivery', async () => {
+        const response = await request(app).delete('/order-detail-deliveries/999');
+        expect(response.status).toBe(404);
+    });
+});

--- a/api/src/routes/orderDetailDelivery.ts
+++ b/api/src/routes/orderDetailDelivery.ts
@@ -107,6 +107,10 @@ const router = express.Router();
 
 let orderDetailDeliveries: OrderDetailDelivery[] = [...seedOrderDetailDeliveries];
 
+export const resetOrderDetailDeliveries = () => {
+  orderDetailDeliveries = [...seedOrderDetailDeliveries];
+};
+
 // Create a new order detail delivery
 router.post('/', (req, res) => {
   const newOrderDetailDelivery: OrderDetailDelivery = req.body;

--- a/api/src/routes/product.test.ts
+++ b/api/src/routes/product.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import productRouter, { resetProducts } from './product';
+import { products as seedProducts } from '../seedData';
+
+let app: express.Express;
+
+describe('Product API', () => {
+    beforeEach(() => {
+        app = express();
+        app.use(express.json());
+        app.use('/products', productRouter);
+        resetProducts();
+    });
+
+    it('should get all products', async () => {
+        const response = await request(app).get('/products');
+        expect(response.status).toBe(200);
+        expect(response.body.length).toBe(seedProducts.length);
+        response.body.forEach((product: any, index: number) => {
+            expect(product).toMatchObject(seedProducts[index]);
+        });
+    });
+
+    it('should get a product by ID', async () => {
+        const response = await request(app).get('/products/1');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(seedProducts[0]);
+    });
+
+    it('should return 404 for non-existing product', async () => {
+        const response = await request(app).get('/products/999');
+        expect(response.status).toBe(404);
+    });
+
+    it('should create a new product', async () => {
+        const newProduct = {
+            productId: 100,
+            supplierId: 1,
+            name: "Test Product",
+            description: "A test product",
+            price: 29.99,
+            sku: "TEST-001",
+            unit: "piece",
+            imgName: "test.png"
+        };
+        const response = await request(app).post('/products').send(newProduct);
+        expect(response.status).toBe(201);
+        expect(response.body).toEqual(newProduct);
+    });
+
+    it('should update a product by ID', async () => {
+        const updatedProduct = {
+            ...seedProducts[0],
+            name: 'Updated SmartFeeder'
+        };
+        const response = await request(app).put('/products/1').send(updatedProduct);
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(updatedProduct);
+    });
+
+    it('should return 404 when updating non-existing product', async () => {
+        const response = await request(app).put('/products/999').send({ name: 'No Product' });
+        expect(response.status).toBe(404);
+    });
+
+    it('should delete a product by ID', async () => {
+        const response = await request(app).delete('/products/1');
+        expect(response.status).toBe(204);
+    });
+
+    it('should return 404 when deleting non-existing product', async () => {
+        const response = await request(app).delete('/products/999');
+        expect(response.status).toBe(404);
+    });
+});

--- a/api/src/routes/product.ts
+++ b/api/src/routes/product.ts
@@ -107,6 +107,10 @@ const router = express.Router();
 
 let products: Product[] = [...seedProducts];
 
+export const resetProducts = () => {
+  products = [...seedProducts];
+};
+
 // Create a new product
 router.post('/', (req, res) => {
   const newProduct: Product = req.body;

--- a/api/src/routes/supplier.test.ts
+++ b/api/src/routes/supplier.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import supplierRouter, { resetSuppliers } from './supplier';
+import { suppliers as seedSuppliers } from '../seedData';
+
+let app: express.Express;
+
+describe('Supplier API', () => {
+    beforeEach(() => {
+        app = express();
+        app.use(express.json());
+        app.use('/suppliers', supplierRouter);
+        resetSuppliers();
+    });
+
+    it('should get all suppliers', async () => {
+        const response = await request(app).get('/suppliers');
+        expect(response.status).toBe(200);
+        expect(response.body.length).toBe(seedSuppliers.length);
+        response.body.forEach((supplier: any, index: number) => {
+            expect(supplier).toMatchObject(seedSuppliers[index]);
+        });
+    });
+
+    it('should get a supplier by ID', async () => {
+        const response = await request(app).get('/suppliers/1');
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(seedSuppliers[0]);
+    });
+
+    it('should return 404 for non-existing supplier', async () => {
+        const response = await request(app).get('/suppliers/999');
+        expect(response.status).toBe(404);
+    });
+
+    it('should create a new supplier', async () => {
+        const newSupplier = {
+            supplierId: 100,
+            name: "Test Supplier",
+            description: "A test supplier",
+            contactPerson: "Test Person",
+            email: "test@supplier.com",
+            phone: "555-9999"
+        };
+        const response = await request(app).post('/suppliers').send(newSupplier);
+        expect(response.status).toBe(201);
+        expect(response.body).toEqual(newSupplier);
+    });
+
+    it('should update a supplier by ID', async () => {
+        const updatedSupplier = {
+            ...seedSuppliers[0],
+            name: 'Updated PurrTech'
+        };
+        const response = await request(app).put('/suppliers/1').send(updatedSupplier);
+        expect(response.status).toBe(200);
+        expect(response.body).toEqual(updatedSupplier);
+    });
+
+    it('should return 404 when updating non-existing supplier', async () => {
+        const response = await request(app).put('/suppliers/999').send({ name: 'No Supplier' });
+        expect(response.status).toBe(404);
+    });
+
+    it('should delete a supplier by ID', async () => {
+        const response = await request(app).delete('/suppliers/1');
+        expect(response.status).toBe(204);
+    });
+
+    it('should return 404 when deleting non-existing supplier', async () => {
+        const response = await request(app).delete('/suppliers/999');
+        expect(response.status).toBe(404);
+    });
+});

--- a/api/src/routes/supplier.ts
+++ b/api/src/routes/supplier.ts
@@ -107,6 +107,10 @@ const router = express.Router();
 
 let suppliers: Supplier[] = [...seedSuppliers];
 
+export const resetSuppliers = () => {
+    suppliers = [...seedSuppliers];
+};
+
 // Create a new supplier
 router.post('/', (req, res) => {
     const newSupplier = req.body as Supplier;

--- a/docs/build.md
+++ b/docs/build.md
@@ -89,8 +89,17 @@ This will start both the API and Frontend in development mode with the integrate
 # Run all tests across all workspaces
 npm run test
 
-# Run tests for a specific workspace
-npm run test --workspace=api
+# Run only the API tests
+npm run test:api
+
+# Run only the Frontend tests
+npm run test:frontend
+
+# Run Frontend tests in watch mode (re-runs on file changes)
+npm run test:watch --workspace=frontend
+
+# Run Frontend tests with coverage report
+npm run test:coverage --workspace=frontend
 ```
 
 ### Linting

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,10 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@types/react-slick": "^0.23.13",

--- a/frontend/src/components/cart/CartPage.test.tsx
+++ b/frontend/src/components/cart/CartPage.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { CartProvider, useCart } from '../../context/CartContext';
+import CartPage from './CartPage';
+
+const sampleItems = [
+  { productId: 1, name: 'SmartFeeder One', price: 129.99, imgName: 'feeder.png' },
+  { productId: 2, name: 'AutoClean Litter Dome', price: 199.99, imgName: 'litter-box.png', discount: 0.25 },
+];
+
+// Helper that pre-populates the cart before rendering CartPage
+const SetupCart: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { addItem } = useCart();
+  React.useEffect(() => {
+    addItem(sampleItems[0], 2);
+    addItem(sampleItems[1], 1);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  return <>{children}</>;
+};
+
+const renderWithCart = (preload = true) => {
+  if (preload) {
+    return render(
+      <CartProvider>
+        <SetupCart>
+          <CartPage />
+        </SetupCart>
+      </CartProvider>
+    );
+  }
+  return render(
+    <CartProvider>
+      <CartPage />
+    </CartProvider>
+  );
+};
+
+describe('CartPage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should show empty cart message when cart is empty', () => {
+    renderWithCart(false);
+    expect(screen.getByText('Your cart is empty')).toBeInTheDocument();
+  });
+
+  it('should disable Proceed To Checkout button when cart is empty', () => {
+    renderWithCart(false);
+    expect(screen.getByText('Proceed To Checkout')).toBeDisabled();
+  });
+
+  it('should disable Clear Cart button when cart is empty', () => {
+    renderWithCart(false);
+    expect(screen.getByText('Clear Cart')).toBeDisabled();
+  });
+
+  it('should render items with name, unit price, and line total', () => {
+    renderWithCart();
+    expect(screen.getByText('SmartFeeder One')).toBeInTheDocument();
+    expect(screen.getByText('AutoClean Litter Dome')).toBeInTheDocument();
+
+    // SmartFeeder: $129.99 each
+    expect(screen.getByTestId('unit-price-1')).toHaveTextContent('$129.99');
+    // Line total: 129.99 * 2 = 259.98
+    expect(screen.getByTestId('line-total-1')).toHaveTextContent('$259.98');
+
+    // Litter Dome with 25% discount: 199.99 * 0.75 = 149.99
+    expect(screen.getByTestId('unit-price-2')).toHaveTextContent('$149.99');
+    // Line total: 149.99 * 1
+    expect(screen.getByTestId('line-total-2')).toHaveTextContent('$149.99');
+  });
+
+  it('should show order summary with subtotal, discount, shipping, and grand total', () => {
+    renderWithCart();
+    // subtotal = 259.98 + 149.9925 ≈ 409.97
+    const subtotal = 129.99 * 2 + 199.99 * 0.75;
+    const discount = subtotal * 0.05;
+    const grandTotal = subtotal - discount + 10;
+
+    expect(screen.getByTestId('subtotal')).toHaveTextContent(`Subtotal: $${subtotal.toFixed(2)}`);
+    expect(screen.getByTestId('discount')).toHaveTextContent(`Discount (5%): -$${discount.toFixed(2)}`);
+    expect(screen.getByTestId('shipping')).toHaveTextContent('Shipping: $10.00');
+    expect(screen.getByTestId('grand-total')).toHaveTextContent(`Grand Total: $${grandTotal.toFixed(2)}`);
+  });
+
+  it('should increment quantity with + button and recalculate total', async () => {
+    const user = userEvent.setup();
+    renderWithCart();
+
+    const plusButton = screen.getByLabelText('Increase quantity of SmartFeeder One');
+    await user.click(plusButton);
+
+    expect(screen.getByTestId('qty-1')).toHaveTextContent('3');
+    // New line total: 129.99 * 3 = 389.97
+    expect(screen.getByTestId('line-total-1')).toHaveTextContent('$389.97');
+  });
+
+  it('should decrement quantity with − button', async () => {
+    const user = userEvent.setup();
+    renderWithCart();
+
+    const minusButton = screen.getByLabelText('Decrease quantity of SmartFeeder One');
+    await user.click(minusButton);
+
+    expect(screen.getByTestId('qty-1')).toHaveTextContent('1');
+  });
+
+  it('should remove item when quantity reaches 0 via − button', async () => {
+    const user = userEvent.setup();
+    renderWithCart();
+
+    // Litter Dome has quantity 1 — click minus once to reach 0
+    const minusButton = screen.getByLabelText('Decrease quantity of AutoClean Litter Dome');
+    await user.click(minusButton);
+
+    expect(screen.queryByText('AutoClean Litter Dome')).not.toBeInTheDocument();
+  });
+
+  it('should clear cart when Clear Cart is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithCart();
+
+    const clearButton = screen.getByText('Clear Cart');
+    await user.click(clearButton);
+
+    expect(screen.getByText('Your cart is empty')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/cart/CartPage.tsx
+++ b/frontend/src/components/cart/CartPage.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { useCart } from '../../context/CartContext';
+
+const SHIPPING_COST = 10;
+const ORDER_DISCOUNT_RATE = 0.05;
+
+const CartPage: React.FC = () => {
+  const { items, removeItem, updateQuantity, clearCart, subtotal } = useCart();
+
+  const orderDiscount = subtotal * ORDER_DISCOUNT_RATE;
+  const grandTotal = subtotal - orderDiscount + SHIPPING_COST;
+
+  return (
+    <div className="min-h-screen pt-20 pb-16 px-4">
+      <div className="max-w-4xl mx-auto">
+        <h1 className="text-3xl font-bold mb-6">Shopping Cart</h1>
+
+        {items.length === 0 ? (
+          <p>Your cart is empty</p>
+        ) : (
+          <div className="space-y-4">
+            {items.map(item => {
+              const effectivePrice = item.discount
+                ? item.price * (1 - item.discount)
+                : item.price;
+              const lineTotal = effectivePrice * item.quantity;
+
+              return (
+                <div key={item.productId} data-testid={`cart-item-${item.productId}`} className="flex items-center justify-between border p-4 rounded">
+                  <div>
+                    <p className="font-semibold">{item.name}</p>
+                    <p data-testid={`unit-price-${item.productId}`}>${effectivePrice.toFixed(2)}</p>
+                  </div>
+                  <div className="flex items-center space-x-3">
+                    <button
+                      aria-label={`Decrease quantity of ${item.name}`}
+                      onClick={() => updateQuantity(item.productId, item.quantity - 1)}
+                    >
+                      −
+                    </button>
+                    <span data-testid={`qty-${item.productId}`}>{item.quantity}</span>
+                    <button
+                      aria-label={`Increase quantity of ${item.name}`}
+                      onClick={() => updateQuantity(item.productId, item.quantity + 1)}
+                    >
+                      +
+                    </button>
+                  </div>
+                  <p data-testid={`line-total-${item.productId}`}>${lineTotal.toFixed(2)}</p>
+                  <button aria-label={`Remove ${item.name}`} onClick={() => removeItem(item.productId)}>
+                    Remove
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        <div className="mt-8 border-t pt-6 space-y-2">
+          <h2 className="text-xl font-bold">Order Summary</h2>
+          <p data-testid="subtotal">Subtotal: ${subtotal.toFixed(2)}</p>
+          <p data-testid="discount">Discount (5%): -${orderDiscount.toFixed(2)}</p>
+          <p data-testid="shipping">Shipping: ${SHIPPING_COST.toFixed(2)}</p>
+          <p data-testid="grand-total" className="text-lg font-bold">
+            Grand Total: ${grandTotal.toFixed(2)}
+          </p>
+        </div>
+
+        <div className="mt-6 flex space-x-4">
+          <button
+            disabled={items.length === 0}
+            className="px-6 py-2 bg-primary text-white rounded disabled:opacity-50"
+          >
+            Proceed To Checkout
+          </button>
+          <button
+            disabled={items.length === 0}
+            onClick={clearCart}
+            className="px-6 py-2 border rounded disabled:opacity-50"
+          >
+            Clear Cart
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CartPage;

--- a/frontend/src/context/CartContext.test.tsx
+++ b/frontend/src/context/CartContext.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import React from 'react';
+import { CartProvider, useCart } from './CartContext';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <CartProvider>{children}</CartProvider>
+);
+
+const sampleItem = {
+  productId: 1,
+  name: 'SmartFeeder One',
+  price: 129.99,
+  imgName: 'feeder.png',
+};
+
+const discountItem = {
+  productId: 2,
+  name: 'AutoClean Litter Dome',
+  price: 199.99,
+  imgName: 'litter-box.png',
+  discount: 0.25,
+};
+
+describe('CartContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should have empty initial state', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+    expect(result.current.items).toEqual([]);
+    expect(result.current.subtotal).toBe(0);
+    expect(result.current.itemCount).toBe(0);
+  });
+
+  it('should add a new product', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+    act(() => result.current.addItem(sampleItem, 2));
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].quantity).toBe(2);
+  });
+
+  it('should increment quantity if product already exists', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+    act(() => result.current.addItem(sampleItem, 1));
+    act(() => result.current.addItem(sampleItem, 3));
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].quantity).toBe(4);
+  });
+
+  it('should ignore quantity <= 0', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+    act(() => result.current.addItem(sampleItem, 0));
+    expect(result.current.items).toHaveLength(0);
+    act(() => result.current.addItem(sampleItem, -1));
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it('should remove a product', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+    act(() => result.current.addItem(sampleItem, 1));
+    act(() => result.current.removeItem(sampleItem.productId));
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it('should update quantity', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+    act(() => result.current.addItem(sampleItem, 1));
+    act(() => result.current.updateQuantity(sampleItem.productId, 5));
+    expect(result.current.items[0].quantity).toBe(5);
+  });
+
+  it('should remove item when quantity updated to 0', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+    act(() => result.current.addItem(sampleItem, 3));
+    act(() => result.current.updateQuantity(sampleItem.productId, 0));
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it('should clear the cart', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+    act(() => result.current.addItem(sampleItem, 1));
+    act(() => result.current.addItem(discountItem, 2));
+    act(() => result.current.clearCart());
+    expect(result.current.items).toHaveLength(0);
+  });
+
+  it('should calculate subtotal with per-product discount', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+    act(() => result.current.addItem(sampleItem, 1)); // 129.99
+    act(() => result.current.addItem(discountItem, 1)); // 199.99 * 0.75 = 149.9925
+    const expected = 129.99 + 199.99 * 0.75;
+    expect(result.current.subtotal).toBeCloseTo(expected, 2);
+  });
+
+  it('should calculate itemCount with multiple items', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+    act(() => result.current.addItem(sampleItem, 2));
+    act(() => result.current.addItem(discountItem, 3));
+    expect(result.current.itemCount).toBe(5);
+  });
+
+  it('should persist cart to localStorage', () => {
+    const { result } = renderHook(() => useCart(), { wrapper });
+    act(() => result.current.addItem(sampleItem, 1));
+    const stored = JSON.parse(localStorage.getItem('octocat-cart')!);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].productId).toBe(sampleItem.productId);
+  });
+
+  it('should read cart from localStorage on init', () => {
+    localStorage.setItem(
+      'octocat-cart',
+      JSON.stringify([{ ...sampleItem, quantity: 4 }])
+    );
+    const { result } = renderHook(() => useCart(), { wrapper });
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].quantity).toBe(4);
+  });
+
+  it('should handle invalid localStorage payload gracefully', () => {
+    localStorage.setItem('octocat-cart', 'not-json!!!');
+    const { result } = renderHook(() => useCart(), { wrapper });
+    expect(result.current.items).toEqual([]);
+  });
+
+  it('should throw error when useCart is used outside CartProvider', () => {
+    expect(() => {
+      renderHook(() => useCart());
+    }).toThrow('useCart must be used within a CartProvider');
+  });
+});

--- a/frontend/src/context/CartContext.tsx
+++ b/frontend/src/context/CartContext.tsx
@@ -1,0 +1,109 @@
+import React, { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+
+export interface CartItem {
+  productId: number;
+  name: string;
+  price: number;
+  quantity: number;
+  imgName: string;
+  discount?: number;
+}
+
+interface CartContextType {
+  items: CartItem[];
+  addItem: (item: Omit<CartItem, 'quantity'>, quantity: number) => void;
+  removeItem: (productId: number) => void;
+  updateQuantity: (productId: number, quantity: number) => void;
+  clearCart: () => void;
+  subtotal: number;
+  itemCount: number;
+}
+
+const CART_STORAGE_KEY = 'octocat-cart';
+
+const CartContext = createContext<CartContextType | undefined>(undefined);
+
+export const CartProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [items, setItems] = useState<CartItem[]>(() => {
+    try {
+      const stored = localStorage.getItem(CART_STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) return parsed;
+      }
+    } catch {
+      // invalid payload — start fresh
+    }
+    return [];
+  });
+
+  useEffect(() => {
+    localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(items));
+  }, [items]);
+
+  const addItem = useCallback((item: Omit<CartItem, 'quantity'>, quantity: number) => {
+    if (quantity <= 0) return;
+    setItems(prev => {
+      const existing = prev.find(i => i.productId === item.productId);
+      if (existing) {
+        return prev.map(i =>
+          i.productId === item.productId
+            ? { ...i, quantity: i.quantity + quantity }
+            : i
+        );
+      }
+      return [...prev, { ...item, quantity }];
+    });
+  }, []);
+
+  const removeItem = useCallback((productId: number) => {
+    setItems(prev => prev.filter(i => i.productId !== productId));
+  }, []);
+
+  const updateQuantity = useCallback((productId: number, quantity: number) => {
+    if (quantity <= 0) {
+      setItems(prev => prev.filter(i => i.productId !== productId));
+      return;
+    }
+    setItems(prev =>
+      prev.map(i => (i.productId === productId ? { ...i, quantity } : i))
+    );
+  }, []);
+
+  const clearCart = useCallback(() => {
+    setItems([]);
+  }, []);
+
+  const subtotal = useMemo(
+    () =>
+      items.reduce((sum, item) => {
+        const effectivePrice = item.discount
+          ? item.price * (1 - item.discount)
+          : item.price;
+        return sum + effectivePrice * item.quantity;
+      }, 0),
+    [items]
+  );
+
+  const itemCount = useMemo(
+    () => items.reduce((sum, item) => sum + item.quantity, 0),
+    [items]
+  );
+
+  const value = useMemo(
+    () => ({ items, addItem, removeItem, updateQuantity, clearCart, subtotal, itemCount }),
+    [items, addItem, removeItem, updateQuantity, clearCart, subtotal, itemCount]
+  );
+
+  return <CartContext.Provider value={value}>{children}</CartContext.Provider>;
+};
+
+export const useCart = (): CartContextType => {
+  const ctx = useContext(CartContext);
+  if (!ctx) {
+    throw new Error('useCart must be used within a CartProvider');
+  }
+  return ctx;
+};
+
+export default CartContext;

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,8 @@
+import '@testing-library/jest-dom';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/react';
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -22,5 +22,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.*", "src/**/*.test.tsx", "src/test/**"]
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,13 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    css: false,
+  },
+})

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "dev:frontend": "npm run dev --workspace=frontend",
     "dev": "concurrently \"npm run dev:api\" \"npm run dev:frontend\"",
     "test": "npm run test --workspaces",
+    "test:api": "npm run test --workspace=api",
+    "test:frontend": "npm run test --workspace=frontend",
     "lint": "npm run lint --workspace=frontend"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Implements comprehensive unit tests for the REST API endpoints and shopping cart functionality as described in #57.

### API Tests (64 tests across 8 files — all passing ✅)

**Modified route files** — exported a `reset*` function in each router for test state isolation:
- `product.ts` → `resetProducts()`
- `supplier.ts` → `resetSuppliers()`
- `headquarters.ts` → `resetHeadquarters()`
- `delivery.ts` → `resetDeliveries()`
- `order.ts` → `resetOrders()`
- `orderDetail.ts` → `resetOrderDetails()`
- `orderDetailDelivery.ts` → `resetOrderDetailDeliveries()`

**New test files** (Vitest + Supertest, following `branch.test.ts` pattern):
- `product.test.ts`, `supplier.test.ts`, `headquarters.test.ts`, `delivery.test.ts` (includes `PUT /:id/status`), `order.test.ts`, `orderDetail.test.ts`, `orderDetailDelivery.test.ts`

Each covers: GET all, GET by id (200/404), POST (201), PUT (200/404), DELETE (204/404).

### Frontend Tests (23 tests across 2 files — all passing ✅)

**New components:**
- `CartContext.tsx` — cart state management with localStorage persistence
- `CartPage.tsx` — shopping cart UI with order summary

**Vitest configuration:**
- `vitest.config.ts` — jsdom environment with setup files
- `src/test/setup.ts` — imports `@testing-library/jest-dom`, cleans DOM + localStorage between tests
- `tsconfig.app.json` — excludes test files from production build

**Cart logic tests** (`CartContext.test.tsx` — 14 tests):
Empty state, addItem, increment existing, ignore qty ≤ 0, removeItem, updateQuantity, remove on qty 0, clearCart, subtotal with discount, itemCount, localStorage persistence (write/read/invalid), useCart outside provider error.

**Cart UI tests** (`CartPage.test.tsx` — 9 tests):
Empty cart message, disabled buttons, rendered items with prices, order summary calculations, +/− buttons, remove on qty 0, clear cart.

### Scripts
- Root: `test:api`, `test:frontend`
- Frontend: `test`, `test:watch`, `test:coverage`

Closes #57